### PR TITLE
パパ活予定管理-修正1

### DIFF
--- a/app/models/papa_event.rb
+++ b/app/models/papa_event.rb
@@ -6,7 +6,7 @@ class PapaEvent < ApplicationRecord
   belongs_to_active_hash :status
 
   belongs_to :user
-  belongs_to :papa_event
+  belongs_to :papa
 
   with_options presence: false do
     validates :end_time_id, numericality: { other_than: 0 }


### PR DESCRIPTION
# What
パパ活予定管理-修正1

# Why
belongs_toをpapaに修正するため（デプロイ時に読み込めないとエラーが出たため）