### PR TITLE
美容予定管理の削除機能 修正1

### DIFF
--- a/app/views/beauty_events/show.html.erb
+++ b/app/views/beauty_events/show.html.erb
@@ -39,7 +39,9 @@
     </ul>
 
     <div>
-      <%= link_to "編集する", edit_beauty_event_path, method: :get %>
-      <%= link_to "削除する", beauty_event_path, method: :delete %>
+    <% if user_signed_in? && current_user.id == beauty.user_id %>
+      <%= link_to "編集する", edit_beauty_event_path(beauty.id), method: :get %>
+      <%= link_to "削除する", beauty_event_path(beauty.id), method: :delete %>
+    <% end %>
     </div>
   <% end %>

--- a/app/views/papa_events/show.html.erb
+++ b/app/views/papa_events/show.html.erb
@@ -45,7 +45,9 @@
       </div>
     </ul>
     <div>
+    <% if user_signed_in? && current_user.id == event.user_id %>
       <%= link_to "編集する", edit_papa_papa_event_path(event.papa_id, event.id), method: :get %>
       <%= link_to "削除する", papa_papa_event_path(event.papa_id, event.id), method: :delete %>
+    <% end %>
     </div>
   <% end %>

--- a/app/views/papas/show.html.erb
+++ b/app/views/papas/show.html.erb
@@ -37,9 +37,12 @@
         <%= "メモ：#{papa.memo}" %>
       </div>
     </ul>
+
     <div>
+    <% if user_signed_in? && current_user.id == papa.user_id %>
       <%= link_to "編集する", edit_papa_path(papa.id), method: :get %>
       <%= link_to "削除する", papa_path(papa.id), method: :delete %>
       <%= link_to "#{papa.name}さんとのパパ活スケジュールを見る", papa_papa_event_path(papa.id) %>
+    <% end %>
     </div>
   <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -4,7 +4,7 @@
 <%= "#{@question.user.nickname}さんによる投稿" %>
 </div>
 
-  <% if user_signed_in? && current_user.id == @question.user.id %>
+  <% if user_signed_in? && current_user.id == @question.user_id %>
     <%= link_to '編集する', edit_question_path(@question.id), method: :get %>
     <%= link_to '削除する', question_path(@question.id), method: :delete %>
   <% end %>


### PR DESCRIPTION
# What
美容予定管理の削除機能 修正1

# Why
美容予定管理の削除機能を修正するため。全てのビューshowにおいて特定のユーザーのみが編集削除ができるパスを記述したため。